### PR TITLE
Add removeViewController function at Coordinator

### DIFF
--- a/Sources/Utility/Coordinator/Coordinator.swift
+++ b/Sources/Utility/Coordinator/Coordinator.swift
@@ -33,6 +33,8 @@ public protocol CoordinatorProtocol: AnyObject {
     func pop(to: DestinationWrapper, animated: Bool)
     func pop(to: UIViewController.Type, animated: Bool)
     func popToRoot(animated: Bool)
+    
+    func removeViewController(_ controller: UIViewController.Type)
 }
 
 public extension CoordinatorProtocol {
@@ -95,6 +97,20 @@ public extension CoordinatorProtocol {
     
     func popToRoot(animated: Bool) {
         sourceNavigationController?.popToRootViewController(animated: animated)
+    }
+    
+}
+
+public extension CoordinatorProtocol {
+    
+    /// Removes specific view controller from navigationController's viewControllers array
+    /// It uses setViewControllers(_:animated:), to update the current view controller stack without pushing or popping each controller explicitly
+    /// - Parameter controller: specific view controller to remove
+    func removeViewController(_ controller: UIViewController.Type) {
+        var array = sourceNavigationController?.viewControllers
+        array?.removeAll(where: { $0.isKind(of: controller.self)} )
+        guard let viewControllers = array else { return }
+        sourceNavigationController?.setViewControllers(viewControllers, animated: true)
     }
     
 }


### PR DESCRIPTION
Coordinator를 이용하여 특정 view controller를 navigation controller의 viewControllers 배열에서 제거합니다.

조금 부연 설명하자면,
A -> B -> C
이렇게 가는 flow에서 C에서 뒤로가기 할 때 A로 가고 싶다.

그러면
`coordinator.removeViewController(B.self)` 를 사용해서 제거하면 됩니다.

되도록이면 `destination`을 `push` 한 뒤에 사용하는 것이 좋을 것 같습니다.

참고:
[Apple Documentation setViewControllers(_:animated:)](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621861-setviewcontrollers)