### PR TITLE
Remove duplicated variable

### DIFF
--- a/Sources/Extension/StringExtension.swift
+++ b/Sources/Extension/StringExtension.swift
@@ -32,25 +32,6 @@ public extension String {
         return nil
     }
     
-    var containsEmoji: Bool { //string에 이모지가 포함된 경우 return true
-        for scalar in unicodeScalars {
-            switch scalar.value {
-            case 0x1F600...0x1F64F, // Emoticons
-                 0x1F300...0x1F5FF, // Misc Symbols and Pictographs
-                 0x1F680...0x1F6FF, // Transport and Map
-                 0x2600...0x26FF,   // Misc symbols
-                 0x2700...0x27BF,   // Dingbats
-                 0xFE00...0xFE0F,   // Variation Selectors
-                 0x1F900...0x1F9FF, // Supplemental Symbols and Pictographs
-                 0x1F1E6...0x1F1FF: // Flags
-                return true
-            default:
-                continue
-            }
-        }
-        return false
-    }
-    
     func convertHtml() -> NSMutableAttributedString {
         guard let data = data(using: .utf8) else { return NSMutableAttributedString() }
         do {


### PR DESCRIPTION
Strings extension에 duplicated variable (`var containsEmoji: Bool`) 제거

해당 부분을 제거한 이유는 범위를 이용해서 이모지를 판단하는데, 이모지는 iOS 업데이트할 때마다 새로 추가되고 있기 때문에,
범위에 해당하지 않는 이모지를 체크하지 못할 수 있는 상황이 발생할 것으로 예상되어 제거했습니다.