### PR TITLE
etnoh - fully visible cells/views 수정

### DIFF
--- a/Sources/Extension/UICollectionViewExtension.swift
+++ b/Sources/Extension/UICollectionViewExtension.swift
@@ -12,8 +12,26 @@ import UIKit
 
 public extension UICollectionView {
     
+    private func findSuperVC(_ responder: UIResponder) -> UIViewController? {
+        guard let next = responder.next else { return nil }
+        
+        guard let vc = next as? UIViewController else {
+            return findSuperVC(next)
+        }
+        
+        return vc
+    }
+
     var fullyVisibleCells: [UICollectionViewCell] {
-        visibleCells.filter { bounds.contains($0.frame) }
+        let superVC = findSuperVC(self)
+        return visibleCells.filter {
+            guard let superview = superVC?.view else {
+                return bounds.contains($0.frame)
+            }
+            
+            let cellRect = convert($0.frame, to: superview)
+            return superview.bounds.contains(cellRect)
+        }
     }
     
     var fullyVisibleCellIndexPaths: [IndexPath] {
@@ -22,8 +40,16 @@ public extension UICollectionView {
     }
 
     func fullyVisibleReusableViews(ofKind elementKind: String) -> [UICollectionReusableView] {
-        visibleSupplementaryViews(ofKind: elementKind)
-            .filter { bounds.contains($0.frame) }
+        let superVC = findSuperVC(self)
+        return visibleSupplementaryViews(ofKind: elementKind)
+            .filter {
+                guard let superview = superVC?.view else {
+                    return bounds.contains($0.frame)
+                }
+                
+                let viewRect = convert($0.frame, to: superview)
+                return superview.bounds.contains(viewRect)
+            }
     }
     
     func fullyVisibleReusableIndexPaths(ofKind elementKind: String) -> [IndexPath] {


### PR DESCRIPTION
- collectionView가 보이지 않는 상태더라도, 해당 bounds 내에 cell이 있을 경우, visibleCell로 간주되는 현상 발생
- 해당 View를 Subview로 가지고 있는 VC를 찾아서, 그 안에 존재하는지 판단

visibleCells는 cell이 collectionView에 보일 경우에만 한정합니다. (collectionView가 보이지 않더라도 상관없음)
fullyVisibleCells는 위에서 100% 노출될 경우 외에도, 자신을 보유한 VC 내에 있는지를 판단하는 것을 더했습니다.
프로퍼티를 추가할까 했지만, 관련 프로퍼티들이 두 배로 늘어나게 되기에,, 고민하다가 기존 프로퍼티 변경으로 대체했습니다.
관련하여 다른 의견 등의 피드백 있으시면 얼마든지 주시면 감사하겠습니다.